### PR TITLE
Add code to support customized table x/z lengths from Directus data

### DIFF
--- a/src/pages/SimVis.js
+++ b/src/pages/SimVis.js
@@ -116,32 +116,34 @@ function SimVis() {
                 );
               } else if (f.type === "Table") {
                 color = 0x00ff00;
+                var x_len = f.x_length;
+                var z_len = f.z_length;
                 element.push(
                   <mesh receiveShadow castShadow key={f.id*10} position={[x,1.75,z]}>
-                    <boxGeometry args={[2,0.1,4]} />
+                    <boxGeometry args={[x_len,0.1,z_len]} />
                     <meshPhongMaterial color={new THREE.Color(color)} />
                   </mesh>
                 );
                 element.push(
-                  <mesh receiveShadow castShadow key={f.id*10+1} position={[x+0.9,0.875,z-1.9]}>
+                  <mesh receiveShadow castShadow key={f.id*10+1} position={[x+x_len/2-0.1,0.875,z-z_len/2+0.1]}>
                     <boxGeometry args={[0.1,1.75,0.1]} />
                     <meshPhongMaterial color={new THREE.Color(color)} />
                   </mesh>
                 );
                 element.push(
-                  <mesh receiveShadow castShadow key={f.id*10+2} position={[x-0.9,0.875,z+1.9]}>
+                  <mesh receiveShadow castShadow key={f.id*10+2} position={[x-x_len/2+0.1,0.875,z+z_len/2-0.1]}>
                     <boxGeometry args={[0.1,1.75,0.1]} />
                     <meshPhongMaterial color={new THREE.Color(color)} />
                   </mesh>
                 );
                 element.push(
-                  <mesh receiveShadow castShadow key={f.id*10+3} position={[x+0.9,0.875,z+1.9]}>
+                  <mesh receiveShadow castShadow key={f.id*10+3} position={[x+x_len/2-0.1,0.875,z+z_len/2-0.1]}>
                     <boxGeometry args={[0.1,1.75,0.1]} />
                     <meshPhongMaterial color={new THREE.Color(color)} />
                   </mesh>
                 );
                 element.push(
-                  <mesh receiveShadow castShadow key={f.id*10+4} position={[x-0.9,0.875,z-1.9]}>
+                  <mesh receiveShadow castShadow key={f.id*10+4} position={[x-x_len/2+0.1,0.875,z-z_len/2+0.1]}>
                     <boxGeometry args={[0.1,1.75,0.1]} />
                     <meshPhongMaterial color={new THREE.Color(color)} />
                   </mesh>


### PR DESCRIPTION
I have created two fields (x_length, z_length) on our Directus schema that represents the size of the table as well as code that can fetch and visualize it. Please review this and the previous pull request (already merged since it blocks this one) for our code review assignment. Thanks!